### PR TITLE
Quit webdriver instead of closing it

### DIFF
--- a/behave_selenium/steps/browser.py
+++ b/behave_selenium/steps/browser.py
@@ -119,7 +119,7 @@ class Browser:
         self.start_time = datetime.today()
 
     def __exit__(self, *_):
-        self._driver.close()
+        self._driver.quit()
         self.finalize()
 
     def check_stream(self, stream, *checks, timeout=None, encoding='utf-8'):


### PR DESCRIPTION
As recommended in https://www.browserstack.com/automate/python, to avoid leaving an open session which will eventually timeout